### PR TITLE
feat: 인자 파싱 메시지 개선

### DIFF
--- a/src/Arg/Command.hs
+++ b/src/Arg/Command.hs
@@ -13,7 +13,7 @@ graphCommand = Graph <$> graphOpts
 
 commands :: Parser Command
 commands =
-  subparser
+  hsubparser
     ( command
         "run"
         ( info
@@ -22,9 +22,7 @@ commands =
                 "run turing machine with single input"
             )
         )
-    )
-    <|> subparser
-      ( command
+        <> command
           "graph"
           ( info
               graphCommand
@@ -32,4 +30,4 @@ commands =
                   "generate a svg graph"
               )
           )
-      )
+    )

--- a/src/Arg/Graph.hs
+++ b/src/Arg/Graph.hs
@@ -8,13 +8,13 @@ graphOpts =
   GraphOpts
     <$> argument
       str
-      ( metavar "FILE"
+      ( metavar "INFILE"
           <> help "tapes input file delimited with newlines"
       )
     <*> strOption
       ( long "output"
           <> short 'o'
-          <> metavar "FILE"
+          <> metavar "OUTFILE"
           <> value "graph.svg"
-          <> help "Path to save Graph svg output"
+          <> help "Path to save Graph svg output (default is `graph.svg`)"
       )


### PR DESCRIPTION
```shelll
./ft_turing --help
```
을 입력했을 때
- 원본
<img width="775" alt="image" src="https://user-images.githubusercontent.com/64446026/192659766-9f6541c9-2c90-44e8-a60d-7c68bb08e8f1.png">

- 수정
<img width="654" alt="image" src="https://user-images.githubusercontent.com/64446026/192659853-0ba11c9c-2ebb-49a4-9401-a5425010d13f.png">

추가적으로 각 COMMAND에 대해서 help 옵션을 만들었음
```shelll
./ft_turing json run --help
```
<img width="467" alt="image" src="https://user-images.githubusercontent.com/64446026/192660189-8a03bef1-0b43-4ca5-bbf8-5b37706d1a05.png">

```shelll
./ft_turing json graph --help
```
<img width="700" alt="image" src="https://user-images.githubusercontent.com/64446026/192659988-58ffd239-8ce5-49ba-a9a6-cb50f90824ab.png">
